### PR TITLE
Add Chinese translation and architecture details

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,188 @@
+# Project Architecture and Guidelines
+
+**Note**: This document is in English. A Chinese translation is available in `AGENTS_cn.md`. Ignore the translation when analyzing code, but keep both files in sync whenever `AGENTS.md` is modified.
+
+This project is a desktop application built with [Tauri](https://tauri.app/) and React/TypeScript. It provides speech-to-text captions for OBS, VRChat, and other platforms. The repository also contains a Rust backend under `src-tauri`.
+
+## Repository Structure
+
+- `src/`
+  - `client/` – React client components and services.
+  - `server/` – server side services invoked from the Tauri application.
+  - `shared/` – utilities shared between client and server (peer connections, pub/sub, etc.).
+  - `assets/`, `i18n.ts`, `index.tsx` – entry point and shared assets.
+- `src-tauri/` – Rust code for the Tauri application and native plugins.
+- `public/` – static HTML files loaded by the app.
+- `tests/` – Playwright tests.
+
+### Detailed Directory Overview
+
+```
+src
+├─ assets
+│  └─ fonts
+├─ client
+│  ├─ elements
+│  │  ├─ image
+│  │  └─ text
+│  ├─ schema
+│  ├─ services
+│  │  └─ sound
+│  └─ ui
+├─ server
+│  ├─ services
+│  │  ├─ stt
+│  │  │  └─ services
+│  │  ├─ tts
+│  │  │  └─ services
+│  │  ├─ translation
+│  │  │  └─ services
+│  │  ├─ vrc
+│  │  │  └─ targets
+│  │  ├─ discord
+│  │  └─ twitch
+│  └─ ui
+│     ├─ inspector
+│     │  └─ components
+│     └─ dropdown
+├─ shared
+│  └─ services
+│     ├─ peer
+│     └─ pubsub
+└─ utils
+
+src-tauri
+├─ src
+│  └─ services
+│     ├─ web
+│     ├─ audio
+│     ├─ keyboard
+│     └─ translate
+└─ icons
+
+tests
+```
+
+## Architecture Overview
+
+```
++-----------+       +--------+       +--------+       +-----------+
+| React UI  | <-->  | Shared | <-->  | Server | <-->  | Rust/Tauri|
+|  Client   |       | Utils  |       |  Node  |       |  Backend  |
++-----------+       +--------+       +--------+       +-----------+
+```
+
+## Tooling
+
+- **Build**: [Vite](https://vitejs.dev/) with React and SWC.
+- **Styling**: [TailwindCSS](https://tailwindcss.com/) and [DaisyUI](https://daisyui.com/).
+- **State Management**: [`valtio`](https://github.com/pmndrs/valtio) with `immer-yjs` for document binding.
+- **Testing**: Playwright.
+- **Formatting**: Prettier (see `package.json` dev dependencies).
+- **Rust**: Tauri plugins configured in `src-tauri`.
+
+## TypeScript Configuration
+
+TypeScript uses strict mode with ESNext modules and React JSX. Paths are aliased under `@/*`. Relevant excerpt from `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "jsx": "react-jsx",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}
+```
+
+## Services Pattern
+
+`src/types.ts` defines a simple interface used by both client and server services:
+
+```ts
+export interface IServiceInterface {
+  init(): void;
+}
+```
+
+Both the client and server construct a collection of service classes. Example from `src/server/index.ts`:
+
+```ts
+export enum Services {
+  vrc = "vrc",
+  stt = "stt",
+  tts = "tts",
+  translation = "translation",
+  twitch = "twitch",
+  discord = "discord",
+  bilibili = "bilibili",
+}
+
+class ApiServer {
+  private readonly _state = new Service_State();
+  public readonly stt = new Service_STT();
+  public readonly tts = new Service_TTS();
+  // ...
+}
+```
+
+Each service implements `init()` and is instantiated in the global `ApiServer` or `ApiClient` objects. Shared utilities (`pubsub`, `peer`) reside under `src/shared`.
+
+## Rust Backend
+
+The Tauri backend uses a plugin-based architecture. `Cargo.toml` lists the dependencies and features required by the application:
+
+```toml
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+tauri = { version = "1.6", features = ["http-all", "dialog-all", "fs-all", "global-shortcut-all", "shell-open", "window-all"] }
+warp = "0.3.3"
+tokio = { version = "1.23.0", features = ["full"] }
+```
+
+Plugins such as `web`, `audio`, `windows_tts`, etc., are initialized in `src-tauri/src/main.rs`.
+
+## React Components
+
+React components are written as functional components using hooks. Example simplified from `src/client/ui/view.tsx`:
+
+```tsx
+const View: FC = () => {
+  const canvas = useGetState(state => state.canvas);
+  const ids = useGetState(state => state.elementsIds);
+  return (
+    <div className="overflow-hidden w-screen h-screen flex items-center justify-center">
+      <div style={{ width: canvas?.w, height: canvas?.h }} className="relative">
+        {ids?.map(id => <ElementSimpleTransform id={id} key={id} />)}
+      </div>
+    </div>
+  );
+};
+```
+
+## Contribution Guidelines
+
+- Use **TypeScript** for all frontend code. Keep the compiler options strict.
+- Format code with **Prettier**.
+- Use functional React components and hooks.
+- Maintain the service architecture – new features should be implemented as services implementing `IServiceInterface`.
+- Follow existing file naming conventions (`Service_Name`, `Element_Name`).
+- Rust code follows the settings in `src-tauri/rustfmt.toml` (imports grouped, line width 150).
+
+## Testing
+
+Run Playwright tests with:
+
+```bash
+pnpm exec playwright test
+```
+
+## Additional Notes
+
+- The client and server communicate via a peer connection and WebSocket pub/sub implemented under `src/shared`.
+- UI styling uses Tailwind with DaisyUI themes defined in `tailwind.config.cjs`.

--- a/AGENTS_cn.md
+++ b/AGENTS_cn.md
@@ -1,0 +1,188 @@
+# 项目架构与开发指南
+
+**注意**：本文档为英文版 `AGENTS.md` 的中文翻译。阅读代码时可以忽略本文件，但若修改 `AGENTS.md`，请同步更新此文件。
+
+本项目是一个基于 [Tauri](https://tauri.app/) 和 React/TypeScript 的桌面应用，用于在 OBS、VRChat 等平台提供语音转文字字幕。仓库中还包含位于 `src-tauri` 目录下的 Rust 后端。
+
+## 仓库结构
+
+- `src/`
+  - `client/` – React 客户端组件与服务
+  - `server/` – 由 Tauri 应用调用的服务端逻辑
+  - `shared/` – 客户端与服务端共享的工具（点对点连接、发布订阅等）
+  - `assets/`、`i18n.ts`、`index.tsx` – 入口及通用资源
+- `src-tauri/` – Tauri 应用及原生插件的 Rust 代码
+- `public/` – 应用加载的静态 HTML
+- `tests/` – Playwright 测试
+
+### 详细目录
+
+```
+src
+├─ assets
+│  └─ fonts
+├─ client
+│  ├─ elements
+│  │  ├─ image
+│  │  └─ text
+│  ├─ schema
+│  ├─ services
+│  │  └─ sound
+│  └─ ui
+├─ server
+│  ├─ services
+│  │  ├─ stt
+│  │  │  └─ services
+│  │  ├─ tts
+│  │  │  └─ services
+│  │  ├─ translation
+│  │  │  └─ services
+│  │  ├─ vrc
+│  │  │  └─ targets
+│  │  ├─ discord
+│  │  └─ twitch
+│  └─ ui
+│     ├─ inspector
+│     │  └─ components
+│     └─ dropdown
+├─ shared
+│  └─ services
+│     ├─ peer
+│     └─ pubsub
+└─ utils
+
+src-tauri
+├─ src
+│  └─ services
+│     ├─ web
+│     ├─ audio
+│     ├─ keyboard
+│     └─ translate
+└─ icons
+
+tests
+```
+
+## 架构概览
+
+```
++-----------+       +--------+       +--------+       +-----------+
+| React UI  | <-->  | Shared | <-->  | Server | <-->  | Rust/Tauri|
+|  客户端   |       | 工具库 |       | Node端 |       | 后端      |
++-----------+       +--------+       +--------+       +-----------+
+```
+
+## 工具链
+
+- **构建**：[Vite](https://vitejs.dev/)（React + SWC）
+- **样式**：[TailwindCSS](https://tailwindcss.com/) 与 [DaisyUI](https://daisyui.com/)
+- **状态管理**：[`valtio`](https://github.com/pmndrs/valtio) 结合 `immer-yjs`
+- **测试**：Playwright
+- **格式化**：Prettier（见 `package.json`）
+- **Rust**：`src-tauri` 中配置的 Tauri 插件
+
+## TypeScript 设置
+
+项目启用 strict 模式，使用 ESNext 模块与 React JSX，路径通过 `@/*` 进行别名。`tsconfig.json` 关键配置如下：
+
+```json
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "strict": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "jsx": "react-jsx",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  }
+}
+```
+
+## 服务模式
+
+`src/types.ts` 定义了客户端与服务端共用的接口：
+
+```ts
+export interface IServiceInterface {
+  init(): void;
+}
+```
+
+客户端和服务端都会构建一系列服务类，示例摘自 `src/server/index.ts`：
+
+```ts
+export enum Services {
+  vrc = "vrc",
+  stt = "stt",
+  tts = "tts",
+  translation = "translation",
+  twitch = "twitch",
+  discord = "discord",
+  bilibili = "bilibili",
+}
+
+class ApiServer {
+  private readonly _state = new Service_State();
+  public readonly stt = new Service_STT();
+  public readonly tts = new Service_TTS();
+  // ...
+}
+```
+
+每个服务都实现 `init()`，并在全局 `ApiServer` 或 `ApiClient` 对象中实例化。共享工具（如 `pubsub`、`peer`）位于 `src/shared`。
+
+## Rust 后端
+
+Tauri 后端采用插件化架构，`Cargo.toml` 中列出了所需依赖：
+
+```toml
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+tauri = { version = "1.6", features = ["http-all", "dialog-all", "fs-all", "global-shortcut-all", "shell-open", "window-all"] }
+warp = "0.3.3"
+tokio = { version = "1.23.0", features = ["full"] }
+```
+
+`src-tauri/src/main.rs` 中初始化诸如 `web`、`audio`、`windows_tts` 等插件。
+
+## React 组件
+
+React 组件以函数式组件结合 hooks 编写，示例取自 `src/client/ui/view.tsx`：
+
+```tsx
+const View: FC = () => {
+  const canvas = useGetState(state => state.canvas);
+  const ids = useGetState(state => state.elementsIds);
+  return (
+    <div className="overflow-hidden w-screen h-screen flex items-center justify-center">
+      <div style={{ width: canvas?.w, height: canvas?.h }} className="relative">
+        {ids?.map(id => <ElementSimpleTransform id={id} key={id} />)}
+      </div>
+    </div>
+  );
+};
+```
+
+## 贡献规范
+
+- 所有前端代码均使用 **TypeScript**，保持编译器严格模式
+- 代码需使用 **Prettier** 格式化
+- 使用函数式 React 组件与 hooks
+- 保持服务式架构，新功能以实现 `IServiceInterface` 的服务形式添加
+- 遵循现有文件命名规范（如 `Service_Name`、`Element_Name`）
+- Rust 代码遵循 `src-tauri/rustfmt.toml` 中的设置（导入分组、行宽 150）
+
+## 测试
+
+执行 Playwright 测试：
+
+```bash
+pnpm exec playwright test
+```
+
+## 其他说明
+
+- 客户端与服务端通过 peer 连接和 WebSocket 发布订阅通信，代码位于 `src/shared`
+- UI 样式使用 Tailwind 与 DaisyUI，主题在 `tailwind.config.cjs` 中定义


### PR DESCRIPTION
## Summary
- add translation guidelines note and architecture overview in `AGENTS.md`
- provide deeper directory structure with ASCII tree
- create `AGENTS_cn.md` Chinese translation of the guide

## Testing
- `pnpm exec playwright test` *(fails: Playwright browsers not installed)*