### PR TITLE
Add edge tts integration UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "use-sync-external-store": "^1.2.0",
     "validator": "^13.11.0",
     "valtio": "^1.11.2",
+    "edge-tts": "^1.0.0",
     "vite-plugin-pwa": "^0.14.7",
     "y-protocols": "^1.0.6",
     "y-utility": "^0.1.3",

--- a/public/i18n/en/translation.json
+++ b/public/i18n/en/translation.json
@@ -128,6 +128,7 @@
     "native_title": "Native",
 
     "tiktok_title": "TikTok",
+    "edge_title": "Edge",
     "windows_title": "Windows"
   },
   "transl": {
@@ -248,7 +249,7 @@
     "section_canvas": "Canvas",
     "section_scenes": "Scenes",
     "field_canvas_size": "Canvas size",
-    "scene_menu_title": "Scene", 
+    "scene_menu_title": "Scene",
     "btn_add_scene": "Add scene",
     "btn_duplicate_scene": "Duplicate scene",
     "btn_remove_scene": "Remove scene"
@@ -258,7 +259,7 @@
     "section_text_source": "Text source",
     "section_text_source_desc": "Where should we get the text from",
     "field_text_profanity_mask": "Profanity mask",
-    
+
     "section_font": "Font",
     "section_font_desc": "Colors, size, shadow, outline",
     "font_color": "Color",

--- a/public/i18n/zh_cn/translation.json
+++ b/public/i18n/zh_cn/translation.json
@@ -106,6 +106,7 @@
   "tts": {
     "title": "文本转语音",
     "field_voice": "音色",
+    "field_stop_with_stream": "随 Twitch 流停止",
 
     "uberduck_title": "Uberduck",
     "uberduck_api_key": "Api key",
@@ -129,6 +130,7 @@
     "native_title": "本地",
 
     "tiktok_title": "抖音",
+    "edge_title": "Edge",
     "windows_title": "Windows"
   },
   "transl": {
@@ -228,7 +230,7 @@
     "section_gpt": "GPT设置",
     "section_auto_reply": "自动回复设置",
     "field_room_id": "房间ID",
-    "field_room_title": "房间标题", 
+    "field_room_title": "房间标题",
     "field_gpt_token": "GPT Token",
     "field_gpt_auto_reply": "自动GPT回复",
     "field_enable_chat": "启用聊天",
@@ -268,7 +270,7 @@
     "section_canvas": "画布",
     "section_scenes": "场景",
     "field_canvas_size": "画布大小",
-    "scene_menu_title": "场景", 
+    "scene_menu_title": "场景",
     "btn_add_scene": "添加场景",
     "btn_duplicate_scene": "复制场景",
     "btn_remove_scene": "删除场景"
@@ -278,7 +280,7 @@
     "section_text_source": "文本源",
     "section_text_source_desc": "从哪里获取文本",
     "field_text_profanity_mask": "脏话屏蔽",
-    
+
     "section_font": "字体",
     "section_font_desc": "颜色, 大小, 阴影, 轮廓",
     "font_color": "颜色",

--- a/public/i18n/zh_tw/translation.json
+++ b/public/i18n/zh_tw/translation.json
@@ -101,6 +101,7 @@
   "tts": {
     "title": "文本轉語音",
     "field_voice": "音色",
+    "field_stop_with_stream": "隨 Twitch 串流停止",
 
     "uberduck_title": "Uberduck",
     "uberduck_api_key": "Api key",
@@ -124,6 +125,7 @@
     "native_title": "本地",
 
     "tiktok_title": "抖音",
+    "edge_title": "Edge",
     "windows_title": "Windows"
   },
   "transl": {
@@ -243,7 +245,7 @@
     "section_canvas": "畫布",
     "section_scenes": "場景",
     "field_canvas_size": "畫布大小",
-    "scene_menu_title": "場景", 
+    "scene_menu_title": "場景",
     "btn_add_scene": "添加場景",
     "btn_duplicate_scene": "復製場景",
     "btn_remove_scene": "刪除場景"
@@ -253,7 +255,7 @@
     "section_text_source": "文本源",
     "section_text_source_desc": "從哪裏獲取文本",
     "field_text_profanity_mask": "臟話屏蔽",
-    
+
     "section_font": "字體",
     "section_font_desc": "顏色, 大小, 陰影, 輪廓",
     "font_color": "顏色",

--- a/src/server/services/tts/schema.ts
+++ b/src/server/services/tts/schema.ts
@@ -8,60 +8,81 @@ export enum TTS_Backends {
   azure = "azure",
   tiktok = "tiktok",
   uberduck = "uberduck",
+  edge = "edge",
   // voicevox = "voicevox",
 }
 
 const zodTTS_Backends = z.nativeEnum(TTS_Backends);
 
-export const Service_TTS_Schema = z.object({
-  source: zSafe(zodTextEventSource, TextEventSource.stt),
-  inputField: zSafe(z.coerce.boolean(), true),
-  backend: zSafe(zodTTS_Backends, TTS_Backends.native),
-  autoStart: zSafe(z.coerce.boolean(), false),
-  stopWithStream: zSafe(z.coerce.boolean(), false),
-  replaceWords: zSafe(z.record(z.coerce.string(), z.coerce.string()), {}),
-  replaceWordsIgnoreCase: zSafe(z.coerce.boolean(), true),
-  native: z.object({
-    voice: zSafe(z.coerce.string(), ""),
-    pitch: zSafe(zStringNumber(), "1"),
-    rate: zSafe(zStringNumber(), "1"),
-    volume: zSafe(zStringNumber(), "1"),
-  }).default({}),
-  tiktok: z.object({
-    device: zSafe(z.coerce.string(), ""),
-    voice: zSafe(z.coerce.string(), ""),
-    volume: zSafe(zStringNumber(), "1"),
-    rate: zSafe(zStringNumber(), "1"),
-  }).default({}),
-  windows: z.object({
-    device: zSafe(z.coerce.string(), ""),
-    voice: zSafe(z.coerce.string(), ""),
-    volume: zSafe(zStringNumber(), "1"),
-    rate: zSafe(zStringNumber(), "1"),
-  }).default({}),
-  uberduck: z.object({
-    api_key: zSafe(z.coerce.string(), ""),
-    secret_key: zSafe(z.coerce.string(), ""),
-    device: zSafe(z.coerce.string(), ""),
-    voice: zSafe(z.coerce.string(), ""),
-    volume: zSafe(zStringNumber(), "1"),
-    rate: zSafe(zStringNumber(), "1"),
-  }).default({}),
-  azure: z.object({
-    device: zSafe(z.coerce.string(), ""),
-    language: zSafe(z.coerce.string(), ""),
-    voice: zSafe(z.coerce.string(), ""),
-    voiceStyle: zSafe(z.coerce.string(), ""),
-    voiceRole: zSafe(z.coerce.string(), ""),
-    voiceVolume: zSafe(z.coerce.string(), "default"),
-    voiceRate: zSafe(z.coerce.string(), "default"),
-    voicePitch: zSafe(z.coerce.string(), "default"),
-    voiceRange: zSafe(z.coerce.string(), "default"),
-    volume: zSafe(zStringNumber(), "1"),
-    rate: zSafe(zStringNumber(), "1"),
-    key: zSafe(z.coerce.string(), ""),
-    location: zSafe(z.coerce.string(), ""),
-  }).default({})
-}).default({});
+export const Service_TTS_Schema = z
+  .object({
+    source: zSafe(zodTextEventSource, TextEventSource.stt),
+    inputField: zSafe(z.coerce.boolean(), true),
+    backend: zSafe(zodTTS_Backends, TTS_Backends.native),
+    autoStart: zSafe(z.coerce.boolean(), false),
+    stopWithStream: zSafe(z.coerce.boolean(), false),
+    replaceWords: zSafe(z.record(z.coerce.string(), z.coerce.string()), {}),
+    replaceWordsIgnoreCase: zSafe(z.coerce.boolean(), true),
+    native: z
+      .object({
+        voice: zSafe(z.coerce.string(), ""),
+        pitch: zSafe(zStringNumber(), "1"),
+        rate: zSafe(zStringNumber(), "1"),
+        volume: zSafe(zStringNumber(), "1"),
+      })
+      .default({}),
+    tiktok: z
+      .object({
+        device: zSafe(z.coerce.string(), ""),
+        voice: zSafe(z.coerce.string(), ""),
+        volume: zSafe(zStringNumber(), "1"),
+        rate: zSafe(zStringNumber(), "1"),
+      })
+      .default({}),
+    windows: z
+      .object({
+        device: zSafe(z.coerce.string(), ""),
+        voice: zSafe(z.coerce.string(), ""),
+        volume: zSafe(zStringNumber(), "1"),
+        rate: zSafe(zStringNumber(), "1"),
+      })
+      .default({}),
+    uberduck: z
+      .object({
+        api_key: zSafe(z.coerce.string(), ""),
+        secret_key: zSafe(z.coerce.string(), ""),
+        device: zSafe(z.coerce.string(), ""),
+        voice: zSafe(z.coerce.string(), ""),
+        volume: zSafe(zStringNumber(), "1"),
+        rate: zSafe(zStringNumber(), "1"),
+      })
+      .default({}),
+    edge: z
+      .object({
+        device: zSafe(z.coerce.string(), ""),
+        voice: zSafe(z.coerce.string(), ""),
+        volume: zSafe(zStringNumber(), "1"),
+        rate: zSafe(zStringNumber(), "1"),
+      })
+      .default({}),
+    azure: z
+      .object({
+        device: zSafe(z.coerce.string(), ""),
+        language: zSafe(z.coerce.string(), ""),
+        voice: zSafe(z.coerce.string(), ""),
+        voiceStyle: zSafe(z.coerce.string(), ""),
+        voiceRole: zSafe(z.coerce.string(), ""),
+        voiceVolume: zSafe(z.coerce.string(), "default"),
+        voiceRate: zSafe(z.coerce.string(), "default"),
+        voicePitch: zSafe(z.coerce.string(), "default"),
+        voiceRange: zSafe(z.coerce.string(), "default"),
+        volume: zSafe(zStringNumber(), "1"),
+        rate: zSafe(zStringNumber(), "1"),
+        key: zSafe(z.coerce.string(), ""),
+        location: zSafe(z.coerce.string(), ""),
+      })
+      .default({}),
+  })
+  .default({});
 
-export type TTS_State = z.infer<typeof Service_TTS_Schema>
+export type TTS_State = z.infer<typeof Service_TTS_Schema>;

--- a/src/server/services/tts/services/edge.ts
+++ b/src/server/services/tts/services/edge.ts
@@ -1,0 +1,42 @@
+import { tts } from "edge-tts";
+import { isEmptyValue } from "../../../../utils";
+import { TTS_State } from "../schema";
+import { ITTSReceiver, ITTSService } from "../types";
+
+export class TTS_EdgeService implements ITTSService {
+  constructor(private bindings: ITTSReceiver) {}
+
+  dispose(): void {}
+
+  get state() {
+    return window.ApiServer.state.services.tts.data.edge;
+  }
+
+  start(state: TTS_State): void {
+    if (Object.values(this.state).some(isEmptyValue))
+      return this.bindings.onStop("Options missing");
+    this.bindings.onStart();
+  }
+
+  async play(value: string) {
+    try {
+      const buffer = await tts(value, {
+        voice: this.state.voice,
+        rate: this.state.rate,
+        volume: this.state.volume,
+      });
+
+      window.ApiServer.sound.enqueueVoiceClip(buffer.buffer, {
+        volume: parseFloat(this.state.volume) ?? 1,
+        rate: parseFloat(this.state.rate) ?? 1,
+        device_name: this.state.device,
+      });
+    } catch (e: any) {
+      this.bindings.onStop(e?.message);
+    }
+  }
+
+  stop(): void {
+    this.bindings.onStop();
+  }
+}

--- a/src/server/ui/inspector/inspector_tts.tsx
+++ b/src/server/ui/inspector/inspector_tts.tsx
@@ -9,19 +9,32 @@ import { azureVoices, tiktokVoices } from "../../services/tts/tts_data";
 import Modal from "../Modal";
 import ServiceButton from "../service-button";
 import Inspector from "./components";
-import { InputCheckbox, InputMapObject, InputMappedGroupSelect, InputNativeAudioOutput, InputRange, InputSelect, InputSelectOption, InputText, InputTextSource } from "./components/input";
+import {
+  InputCheckbox,
+  InputMapObject,
+  InputMappedGroupSelect,
+  InputNativeAudioOutput,
+  InputRange,
+  InputSelect,
+  InputSelectOption,
+  InputText,
+  InputTextSource,
+} from "./components/input";
 import classNames from "classnames";
 import { useTranslation } from "react-i18next";
 
 type WindowsToken = {
   id: string;
   label: string;
-}
-type WindowsConfig = { devices: WindowsToken[], voices: WindowsToken[] };
+};
+type WindowsConfig = { devices: WindowsToken[]; voices: WindowsToken[] };
 const Windows: FC = () => {
-  const {t} = useTranslation();
+  const { t } = useTranslation();
   const data = useSnapshot(window.ApiServer.state.services.tts.data.windows);
-  const handleUpdate = <K extends keyof TTS_State["windows"]>(key: K, v: TTS_State["windows"][K]) => window.ApiServer.patchService("tts", s => s.data.windows[key] = v);
+  const handleUpdate = <K extends keyof TTS_State["windows"]>(
+    key: K,
+    v: TTS_State["windows"][K]
+  ) => window.ApiServer.patchService("tts", (s) => (s.data.windows[key] = v));
 
   const [config, setConfig] = useState<WindowsConfig>();
 
@@ -29,174 +42,330 @@ const Windows: FC = () => {
     invoke<WindowsConfig>("plugin:windows_tts|get_voices").then(setConfig);
   }, []);
 
-  return <>
-    <Inspector.SubHeader>{t('tts.windows_title')}</Inspector.SubHeader>
-    <InputSelect
-      value={data.device}
-      onValueChange={e => handleUpdate("device", e)}
-      options={config?.devices.map(d => ({label: d.label, value: d.id })) || []}
-      label="common.field_output_device" />
-    {/* <InputNativeAudioOutput label="Audio Output" value={pr.device} onChange={e => handleUpdate("device", e)} /> */}
-    <InputSelect
-      value={data.voice}
-      onValueChange={e => handleUpdate("voice", e)}
-      options={config?.voices.map(d => ({ ...d, value: d.id })) || []}
-      label="tts.field_voice" />
-    <InputRange value={data.volume} onChange={e => handleUpdate("volume", e.target.value)} label="common.field_volume" step="0.05" min="0" max="1" />
-    <InputRange value={data.rate} onChange={e => handleUpdate("rate", e.target.value)} label="common.field_rate" step="0.05" min="0.1" max="5" />
-  </>
-}
+  return (
+    <>
+      <Inspector.SubHeader>{t("tts.windows_title")}</Inspector.SubHeader>
+      <InputSelect
+        value={data.device}
+        onValueChange={(e) => handleUpdate("device", e)}
+        options={
+          config?.devices.map((d) => ({ label: d.label, value: d.id })) || []
+        }
+        label="common.field_output_device"
+      />
+      {/* <InputNativeAudioOutput label="Audio Output" value={pr.device} onChange={e => handleUpdate("device", e)} /> */}
+      <InputSelect
+        value={data.voice}
+        onValueChange={(e) => handleUpdate("voice", e)}
+        options={config?.voices.map((d) => ({ ...d, value: d.id })) || []}
+        label="tts.field_voice"
+      />
+      <InputRange
+        value={data.volume}
+        onChange={(e) => handleUpdate("volume", e.target.value)}
+        label="common.field_volume"
+        step="0.05"
+        min="0"
+        max="1"
+      />
+      <InputRange
+        value={data.rate}
+        onChange={(e) => handleUpdate("rate", e.target.value)}
+        label="common.field_rate"
+        step="0.05"
+        min="0.1"
+        max="5"
+      />
+    </>
+  );
+};
 
 const TikTok: FC = () => {
-  const {t} = useTranslation();
+  const { t } = useTranslation();
   const data = useSnapshot(window.ApiServer.state.services.tts.data.tiktok);
-  const handleUpdate = <K extends keyof TTS_State["tiktok"]>(key: K, v: TTS_State["tiktok"][K]) => window.ApiServer.patchService("tts", s => s.data.tiktok[key] = v);
-  return <>
-    <Inspector.SubHeader>{t("tts.tiktok_title")}</Inspector.SubHeader>
-    <InputNativeAudioOutput label="common.field_output_device" value={data.device} onChange={e => handleUpdate("device", e)} />
-    <InputSelect
-      value={data.voice}
-      onValueChange={e => handleUpdate("voice", e)}
-      options={tiktokVoices}
-      label="tts.field_voice" />
-    <InputRange value={data.volume} onChange={e => handleUpdate("volume", e.target.value)} label="common.field_volume" step="0.05" min="0" max="1" />
-    {/* <InputRange value={data.rate} onChange={e => handleUpdate("rate", e.target.value)} label={`Rate (${data.rate})`} step="0.05" min="0.1" max="5" /> */}
-  </>
-}
+  const handleUpdate = <K extends keyof TTS_State["tiktok"]>(
+    key: K,
+    v: TTS_State["tiktok"][K]
+  ) => window.ApiServer.patchService("tts", (s) => (s.data.tiktok[key] = v));
+  return (
+    <>
+      <Inspector.SubHeader>{t("tts.tiktok_title")}</Inspector.SubHeader>
+      <InputNativeAudioOutput
+        label="common.field_output_device"
+        value={data.device}
+        onChange={(e) => handleUpdate("device", e)}
+      />
+      <InputSelect
+        value={data.voice}
+        onValueChange={(e) => handleUpdate("voice", e)}
+        options={tiktokVoices}
+        label="tts.field_voice"
+      />
+      <InputRange
+        value={data.volume}
+        onChange={(e) => handleUpdate("volume", e.target.value)}
+        label="common.field_volume"
+        step="0.05"
+        min="0"
+        max="1"
+      />
+      {/* <InputRange value={data.rate} onChange={e => handleUpdate("rate", e.target.value)} label={`Rate (${data.rate})`} step="0.05" min="0.1" max="5" /> */}
+    </>
+  );
+};
 
 const Native: FC = () => {
-  const {t} = useTranslation();
+  const { t } = useTranslation();
   const data = useSnapshot(window.ApiServer.state.services.tts.data.native);
-  const handleUpdate = <K extends keyof TTS_State["native"]>(key: K, v: TTS_State["native"][K]) => window.ApiServer.patchService("tts", s => s.data.native[key] = v);
+  const handleUpdate = <K extends keyof TTS_State["native"]>(
+    key: K,
+    v: TTS_State["native"][K]
+  ) => window.ApiServer.patchService("tts", (s) => (s.data.native[key] = v));
   const state = useSnapshot(window.ApiServer.tts.serviceState);
-  const [voices, setVoices] = useState<{ label: string, value: string }[]>([]);
+  const [voices, setVoices] = useState<{ label: string; value: string }[]>([]);
 
   useEffect(() => {
     let voices = window.speechSynthesis.getVoices();
 
     if (voices.length) {
-      setVoices(voices.map(v => ({ label: v.name, value: v.voiceURI })));
-    }
-    else {
+      setVoices(voices.map((v) => ({ label: v.name, value: v.voiceURI })));
+    } else {
       window.speechSynthesis.onvoiceschanged = () => {
-        let options = window.speechSynthesis.getVoices().map(v => ({ label: v.name, value: v.voiceURI }))
+        let options = window.speechSynthesis
+          .getVoices()
+          .map((v) => ({ label: v.name, value: v.voiceURI }));
         setVoices(options);
-      }
+      };
     }
-
   }, []);
 
-  return <>
-    <Inspector.SubHeader>{t('tts.native_title')}</Inspector.SubHeader>
-    <Inspector.Deactivatable active={state.status === ServiceNetworkState.disconnected}>
-      <InputSelect
-        value={data.voice}
-        onValueChange={e => handleUpdate("voice", e)}
-        options={voices}
-        label="tts.field_voice" />
-    </Inspector.Deactivatable>
+  return (
+    <>
+      <Inspector.SubHeader>{t("tts.native_title")}</Inspector.SubHeader>
+      <Inspector.Deactivatable
+        active={state.status === ServiceNetworkState.disconnected}
+      >
+        <InputSelect
+          value={data.voice}
+          onValueChange={(e) => handleUpdate("voice", e)}
+          options={voices}
+          label="tts.field_voice"
+        />
+      </Inspector.Deactivatable>
 
-    <InputRange value={data.pitch} onChange={e => handleUpdate("pitch", e.target.value)} label="common.field_pitch" step="0.1" min="0" max="2" />
-    <InputRange value={data.rate} onChange={e => handleUpdate("rate", e.target.value)} label="common.field_rate" step="0.1" min="0.1" max="10" />
-    <InputRange value={data.volume} onChange={e => handleUpdate("volume", e.target.value)} label="common.field_volume" step="0.05" min="0" max="1" />
-  </>
-}
+      <InputRange
+        value={data.pitch}
+        onChange={(e) => handleUpdate("pitch", e.target.value)}
+        label="common.field_pitch"
+        step="0.1"
+        min="0"
+        max="2"
+      />
+      <InputRange
+        value={data.rate}
+        onChange={(e) => handleUpdate("rate", e.target.value)}
+        label="common.field_rate"
+        step="0.1"
+        min="0.1"
+        max="10"
+      />
+      <InputRange
+        value={data.volume}
+        onChange={(e) => handleUpdate("volume", e.target.value)}
+        label="common.field_volume"
+        step="0.05"
+        min="0"
+        max="1"
+      />
+    </>
+  );
+};
 
 const Azure: FC = () => {
-  const {t} = useTranslation();
+  const { t } = useTranslation();
   const data = useSnapshot(window.ApiServer.state.services.tts.data.azure);
-  const handleUpdate = <K extends keyof TTS_State["azure"]>(key: K, v: TTS_State["azure"][K]) => window.ApiServer.state.services.tts.data.azure[key] = v;
+  const handleUpdate = <K extends keyof TTS_State["azure"]>(
+    key: K,
+    v: TTS_State["azure"][K]
+  ) => (window.ApiServer.state.services.tts.data.azure[key] = v);
   const state = useSnapshot(window.ApiServer.tts.serviceState);
-  const [voiceStyles, setVoiceStyles] = useState<{ label: string, value: string }[]>([]);
-  const [voiceRoles, setVoiceRoles] = useState<{ label: string, value: string }[]>([]);
+  const [voiceStyles, setVoiceStyles] = useState<
+    { label: string; value: string }[]
+  >([]);
+  const [voiceRoles, setVoiceRoles] = useState<
+    { label: string; value: string }[]
+  >([]);
 
-  const updateVoice = (value: { group: string, option: string }) => {
-    window.ApiServer.state.services.tts.data.azure.language   = value.group;
-    window.ApiServer.state.services.tts.data.azure.voice      = value.option;
+  const updateVoice = (value: { group: string; option: string }) => {
+    window.ApiServer.state.services.tts.data.azure.language = value.group;
+    window.ApiServer.state.services.tts.data.azure.voice = value.option;
     // clear voice and role in state
     window.ApiServer.state.services.tts.data.azure.voiceStyle = "";
-    window.ApiServer.state.services.tts.data.azure.voiceRole  = "";
+    window.ApiServer.state.services.tts.data.azure.voiceRole = "";
   };
 
   useEffect(() => {
     // find voice
     // set styles and roles
-    if (!data.language || !data.voice)
-      return;
+    if (!data.language || !data.voice) return;
 
-    const voice = azureVoices[data.language].find(voice => voice[0] === data.voice)
+    const voice = azureVoices[data.language].find(
+      (voice) => voice[0] === data.voice
+    );
     const voiceParams = voice?.[2];
-    setVoiceStyles(voiceParams?.styles ? [{ label: "None", value: "" }, ...voiceParams.styles.map(style => ({ label: style, value: style }))] : []);
-    setVoiceRoles(voiceParams?.roles ? [{ label: "None", value: "" }, ...voiceParams.roles.map(roles => ({ label: roles, value: roles }))] : []);
-
+    setVoiceStyles(
+      voiceParams?.styles
+        ? [
+            { label: "None", value: "" },
+            ...voiceParams.styles.map((style) => ({
+              label: style,
+              value: style,
+            })),
+          ]
+        : []
+    );
+    setVoiceRoles(
+      voiceParams?.roles
+        ? [
+            { label: "None", value: "" },
+            ...voiceParams.roles.map((roles) => ({
+              label: roles,
+              value: roles,
+            })),
+          ]
+        : []
+    );
   }, [data.language, data.voice]);
 
-  return <>
-    <Inspector.SubHeader>{t('tts.azure_title')}</Inspector.SubHeader>
-    <Inspector.Deactivatable active={state.status === ServiceNetworkState.disconnected}>
-      <InputNativeAudioOutput label="common.field_output_device" value={data.device} onChange={e => handleUpdate("device", e)} />
-      <InputText type="password" label="tts.azure_key" value={data.key} onChange={e => handleUpdate("key", e.target.value)} />
-      <InputText type="password" label="tts.azure_location" value={data.location} onChange={e => handleUpdate("location", e.target.value)} />
-    </Inspector.Deactivatable>
+  return (
+    <>
+      <Inspector.SubHeader>{t("tts.azure_title")}</Inspector.SubHeader>
+      <Inspector.Deactivatable
+        active={state.status === ServiceNetworkState.disconnected}
+      >
+        <InputNativeAudioOutput
+          label="common.field_output_device"
+          value={data.device}
+          onChange={(e) => handleUpdate("device", e)}
+        />
+        <InputText
+          type="password"
+          label="tts.azure_key"
+          value={data.key}
+          onChange={(e) => handleUpdate("key", e.target.value)}
+        />
+        <InputText
+          type="password"
+          label="tts.azure_location"
+          value={data.location}
+          onChange={(e) => handleUpdate("location", e.target.value)}
+        />
+      </Inspector.Deactivatable>
 
-    <InputMappedGroupSelect
-      labelGroup="common.field_language"
-      labelOption="common.field_dialect"
-      value={{ group: data.language, option: data.voice }}
-      onChange={updateVoice}
-      library={azureVoices} />
+      <InputMappedGroupSelect
+        labelGroup="common.field_language"
+        labelOption="common.field_dialect"
+        value={{ group: data.language, option: data.voice }}
+        onChange={updateVoice}
+        library={azureVoices}
+      />
 
-    {voiceStyles.length > 0 && <InputSelect value={data.voiceStyle} options={voiceStyles} label="tts.azure_voice_style" onValueChange={e => handleUpdate("voiceStyle", e)} />}
-    {voiceRoles.length > 0 && <InputSelect value={data.voiceRole} options={voiceRoles} label="tts.azure_voice_role" onValueChange={e => handleUpdate("voiceRole", e)} />}
-    <InputSelect options={[
-      { label: "silent", value: "silent" },
-      { label: "x-soft", value: "x-soft" },
-      { label: "soft", value: "soft" },
-      { label: "medium", value: "medium" },
-      { label: "loud", value: "loud" },
-      { label: "x-loud", value: "x-loud" },
-      { label: "default", value: "default" }
-    ]} label="tts.azure_voice_volume" value={data.voiceVolume} onValueChange={e => handleUpdate("voiceVolume", e)} />
-    <InputSelect options={[
-      { label: "x-slow", value: "x-slow" },
-      { label: "slow", value: "slow" },
-      { label: "medium", value: "medium" },
-      { label: "fast", value: "fast" },
-      { label: "x-fast", value: "x-fast" },
-      { label: "default", value: "default" },
-    ]} label="tts.azure_voice_rate" value={data.voiceRate} onValueChange={e => handleUpdate("voiceRate", e)} />
-    <InputSelect options={[
-      { label: "x-low", value: "x-low" },
-      { label: "low", value: "low" },
-      { label: "medium", value: "medium" },
-      { label: "high", value: "high" },
-      { label: "x-high", value: "x-high" },
-      { label: "default", value: "default" },
-    ]} label="tts.azure_voice_pitch" value={data.voicePitch} onValueChange={e => handleUpdate("voicePitch", e)} />
-    <InputSelect options={[
-      { label: "x-low", value: "x-low" },
-      { label: "low", value: "low" },
-      { label: "medium", value: "medium" },
-      { label: "high", value: "high" },
-      { label: "x-high", value: "x-high" },
-      { label: "default", value: "default" },
-    ]} label="tts.azure_voice_range" value={data.voiceRange} onValueChange={e => handleUpdate("voiceRange", e)} />
-    <InputRange value={data.volume} onChange={e => handleUpdate("volume", e.target.value)} label="common.field_volume" step="0.05" min="0" max="1" />
-    {/* <InputRange value={data.rate} onChange={e => handleUpdate("rate", e.target.value)} label={`Rate (${data.rate})`} step="0.05" min="0.1" max="5" /> */}
-  </>
-}
+      {voiceStyles.length > 0 && (
+        <InputSelect
+          value={data.voiceStyle}
+          options={voiceStyles}
+          label="tts.azure_voice_style"
+          onValueChange={(e) => handleUpdate("voiceStyle", e)}
+        />
+      )}
+      {voiceRoles.length > 0 && (
+        <InputSelect
+          value={data.voiceRole}
+          options={voiceRoles}
+          label="tts.azure_voice_role"
+          onValueChange={(e) => handleUpdate("voiceRole", e)}
+        />
+      )}
+      <InputSelect
+        options={[
+          { label: "silent", value: "silent" },
+          { label: "x-soft", value: "x-soft" },
+          { label: "soft", value: "soft" },
+          { label: "medium", value: "medium" },
+          { label: "loud", value: "loud" },
+          { label: "x-loud", value: "x-loud" },
+          { label: "default", value: "default" },
+        ]}
+        label="tts.azure_voice_volume"
+        value={data.voiceVolume}
+        onValueChange={(e) => handleUpdate("voiceVolume", e)}
+      />
+      <InputSelect
+        options={[
+          { label: "x-slow", value: "x-slow" },
+          { label: "slow", value: "slow" },
+          { label: "medium", value: "medium" },
+          { label: "fast", value: "fast" },
+          { label: "x-fast", value: "x-fast" },
+          { label: "default", value: "default" },
+        ]}
+        label="tts.azure_voice_rate"
+        value={data.voiceRate}
+        onValueChange={(e) => handleUpdate("voiceRate", e)}
+      />
+      <InputSelect
+        options={[
+          { label: "x-low", value: "x-low" },
+          { label: "low", value: "low" },
+          { label: "medium", value: "medium" },
+          { label: "high", value: "high" },
+          { label: "x-high", value: "x-high" },
+          { label: "default", value: "default" },
+        ]}
+        label="tts.azure_voice_pitch"
+        value={data.voicePitch}
+        onValueChange={(e) => handleUpdate("voicePitch", e)}
+      />
+      <InputSelect
+        options={[
+          { label: "x-low", value: "x-low" },
+          { label: "low", value: "low" },
+          { label: "medium", value: "medium" },
+          { label: "high", value: "high" },
+          { label: "x-high", value: "x-high" },
+          { label: "default", value: "default" },
+        ]}
+        label="tts.azure_voice_range"
+        value={data.voiceRange}
+        onValueChange={(e) => handleUpdate("voiceRange", e)}
+      />
+      <InputRange
+        value={data.volume}
+        onChange={(e) => handleUpdate("volume", e.target.value)}
+        label="common.field_volume"
+        step="0.05"
+        min="0"
+        max="1"
+      />
+      {/* <InputRange value={data.rate} onChange={e => handleUpdate("rate", e.target.value)} label={`Rate (${data.rate})`} step="0.05" min="0.1" max="5" /> */}
+    </>
+  );
+};
 
 const VoiceVox: FC = () => {
   const handleQuery = async () => {
-    let resp = await fetch("http://127.0.0.1:50021/audio_query?text=text&speaker=1", {
-      method: "POST",
-      body: JSON.stringify({
-        query: {
-          text: "text",
-          speaker: 1,
-        }
-      })
-    });
+    let resp = await fetch(
+      "http://127.0.0.1:50021/audio_query?text=text&speaker=1",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          query: {
+            text: "text",
+            speaker: 1,
+          },
+        }),
+      }
+    );
     const jsn = await resp.json();
   };
 
@@ -209,7 +378,7 @@ const VoiceVox: FC = () => {
     let resp = await fetch("http://127.0.0.1:50021/synthesis?speaker=0", {
       headers: {
         // 'Accept': 'audio/wav',
-        'Content-type': 'application/json'
+        "Content-type": "application/json",
       },
       method: "POST",
       body: JSON.stringify({
@@ -217,16 +386,19 @@ const VoiceVox: FC = () => {
           {
             accent: 1,
             is_interrogative: false,
-            moras: [{
-              consonant: "t",
-              consonant_length: 0.0727369412779808,
-              pitch: 5.911419868469238,
-              text: "テ",
-              vowel: "e",
-              vowel_length: 0.1318332552909851,
-            }],
-            pause_mora: null
-          }],
+            moras: [
+              {
+                consonant: "t",
+                consonant_length: 0.0727369412779808,
+                pitch: 5.911419868469238,
+                text: "テ",
+                vowel: "e",
+                vowel_length: 0.1318332552909851,
+              },
+            ],
+            pause_mora: null,
+          },
+        ],
         speedScale: 1,
         pitchScale: 1,
         intonationScale: 1,
@@ -235,126 +407,306 @@ const VoiceVox: FC = () => {
         postPhonemeLength: 1,
         outputSamplingRate: 1,
         outputStereo: true,
-      })
+      }),
     });
     const jsn = await resp.arrayBuffer();
   };
 
-  return <>
-    voicevox
-    <button onClick={handleQuery}>Query</button>
-    <button onClick={handleSynth}>Synth</button>
-    <button onClick={handleQueryVoices}>Voices</button>
-  </>
-}
+  return (
+    <>
+      voicevox
+      <button onClick={handleQuery}>Query</button>
+      <button onClick={handleSynth}>Synth</button>
+      <button onClick={handleQueryVoices}>Voices</button>
+    </>
+  );
+};
 
-const uberduckVoices = proxy<{value: InputSelectOption[]}>({
-  value: []
+const uberduckVoices = proxy<{ value: InputSelectOption[] }>({
+  value: [],
+});
+
+const edgeVoices = proxy<{ value: InputSelectOption[] }>({
+  value: [],
 });
 
 const UberDuck: FC = () => {
-  const {t} = useTranslation();
+  const { t } = useTranslation();
   const data = useSnapshot(window.ApiServer.state.services.tts.data.uberduck);
   const state = useSnapshot(window.ApiServer.tts.serviceState);
-  const handleUpdate = <K extends keyof TTS_State["uberduck"]>(key: K, v: TTS_State["uberduck"][K]) => window.ApiServer.patchService("tts", s => s.data.uberduck[key] = v);
-  const {value: voices} = useSnapshot(uberduckVoices);
+  const handleUpdate = <K extends keyof TTS_State["uberduck"]>(
+    key: K,
+    v: TTS_State["uberduck"][K]
+  ) => window.ApiServer.patchService("tts", (s) => (s.data.uberduck[key] = v));
+  const { value: voices } = useSnapshot(uberduckVoices);
   const [loadingVoices, setLoadingVoices] = useState(false);
 
   const loadVoices = () => {
-    if (!data.api_key || !data.secret_key)
-      return;
+    if (!data.api_key || !data.secret_key) return;
     setLoadingVoices(true);
-    invoke("plugin:uberduck_tts|get_voices", {auth: {
-      api_key: data.api_key,
-      secret_key: data.secret_key,
-    }}).then(res => {
-      if (Array.isArray(res))
-        uberduckVoices.value = res.map(v => ({value: v.voicemodel_uuid, label: v.display_name}));
-    }).finally(() => setLoadingVoices(false));
-  }
+    invoke("plugin:uberduck_tts|get_voices", {
+      auth: {
+        api_key: data.api_key,
+        secret_key: data.secret_key,
+      },
+    })
+      .then((res) => {
+        if (Array.isArray(res))
+          uberduckVoices.value = res.map((v) => ({
+            value: v.voicemodel_uuid,
+            label: v.display_name,
+          }));
+      })
+      .finally(() => setLoadingVoices(false));
+  };
 
   useEffect(() => {
-    if (!voices.length)
-      loadVoices();
+    if (!voices.length) loadVoices();
   }, []);
-  return <>
-    <Inspector.SubHeader>{t('tts.uberduck_title')}</Inspector.SubHeader>
-    <Inspector.Deactivatable active={state.status === ServiceNetworkState.disconnected}>
-      <InputNativeAudioOutput label="common.field_output_device" value={data.device} onChange={e => handleUpdate("device", e)} />
-      <InputText label="tts.uberduck_api_key" value={data.api_key} onChange={e => handleUpdate("api_key", e.target.value)} />
-      <InputText label="tts.uberduck_secret" type="password" value={data.secret_key} onChange={e => handleUpdate("secret_key", e.target.value)} />
-      <Inspector.Description>
-        <span className="text-base-content/60 text-xs mt-2">
-          {t('tts.uberduck_voice_desc')}<br/>
-          <a className="link link-primary link-hover" target="_blank" href="https://app.uberduck.ai/speak#mode=tts-reference&voice=zwf">{t('tts.uberduck_voice_desc_link')}</a>
-        </span>
-      </Inspector.Description>
-      <InputSelect
-        value={data.voice}
-        onValueChange={e => handleUpdate("voice", e)}
-        options={voices as InputSelectOption[]}
-        label="tts.field_voice" />
-      <button onClick={loadVoices} className={classNames("btn btn-xs disabled", {loading: loadingVoices, "btn-disabled": !data.api_key || !data.secret_key})}>{loadingVoices ? t('tts.uberduck_voice_status_updating') : t('tts.uberduck_voice_status_reload')}</button>
-      <InputRange label="common.field_volume" value={data.volume} onChange={e => handleUpdate("volume", e.target.value)} step="0.05" min="0" max="1" />
-    </Inspector.Deactivatable>
-  </>
-}
+  return (
+    <>
+      <Inspector.SubHeader>{t("tts.uberduck_title")}</Inspector.SubHeader>
+      <Inspector.Deactivatable
+        active={state.status === ServiceNetworkState.disconnected}
+      >
+        <InputNativeAudioOutput
+          label="common.field_output_device"
+          value={data.device}
+          onChange={(e) => handleUpdate("device", e)}
+        />
+        <InputText
+          label="tts.uberduck_api_key"
+          value={data.api_key}
+          onChange={(e) => handleUpdate("api_key", e.target.value)}
+        />
+        <InputText
+          label="tts.uberduck_secret"
+          type="password"
+          value={data.secret_key}
+          onChange={(e) => handleUpdate("secret_key", e.target.value)}
+        />
+        <Inspector.Description>
+          <span className="text-base-content/60 text-xs mt-2">
+            {t("tts.uberduck_voice_desc")}
+            <br />
+            <a
+              className="link link-primary link-hover"
+              target="_blank"
+              href="https://app.uberduck.ai/speak#mode=tts-reference&voice=zwf"
+            >
+              {t("tts.uberduck_voice_desc_link")}
+            </a>
+          </span>
+        </Inspector.Description>
+        <InputSelect
+          value={data.voice}
+          onValueChange={(e) => handleUpdate("voice", e)}
+          options={voices as InputSelectOption[]}
+          label="tts.field_voice"
+        />
+        <button
+          onClick={loadVoices}
+          className={classNames("btn btn-xs disabled", {
+            loading: loadingVoices,
+            "btn-disabled": !data.api_key || !data.secret_key,
+          })}
+        >
+          {loadingVoices
+            ? t("tts.uberduck_voice_status_updating")
+            : t("tts.uberduck_voice_status_reload")}
+        </button>
+        <InputRange
+          label="common.field_volume"
+          value={data.volume}
+          onChange={(e) => handleUpdate("volume", e.target.value)}
+          step="0.05"
+          min="0"
+          max="1"
+        />
+      </Inspector.Deactivatable>
+    </>
+  );
+};
+
+const Edge: FC = () => {
+  const { t } = useTranslation();
+  const data = useSnapshot(window.ApiServer.state.services.tts.data.edge);
+  const state = useSnapshot(window.ApiServer.tts.serviceState);
+  const handleUpdate = <K extends keyof TTS_State["edge"]>(
+    key: K,
+    v: TTS_State["edge"][K]
+  ) => window.ApiServer.patchService("tts", (s) => (s.data.edge[key] = v));
+  const { value: voices } = useSnapshot(edgeVoices);
+
+  useEffect(() => {
+    if (!voices.length) {
+      import("edge-tts")
+        .then((m) => m.getVoices())
+        .then((v) => {
+          edgeVoices.value = v.map((voice: any) => ({
+            label: voice.FriendlyName,
+            value: voice.ShortName,
+          }));
+        })
+        .catch(() => {});
+    }
+  }, [voices.length]);
+
+  return (
+    <>
+      <Inspector.SubHeader>{t("tts.edge_title")}</Inspector.SubHeader>
+      <Inspector.Deactivatable
+        active={state.status === ServiceNetworkState.disconnected}
+      >
+        <InputNativeAudioOutput
+          label="common.field_output_device"
+          value={data.device}
+          onChange={(e) => handleUpdate("device", e)}
+        />
+        <InputSelect
+          value={data.voice}
+          onValueChange={(e) => handleUpdate("voice", e)}
+          options={voices as InputSelectOption[]}
+          label="tts.field_voice"
+        />
+        <InputRange
+          value={data.volume}
+          onChange={(e) => handleUpdate("volume", e.target.value)}
+          label="common.field_volume"
+          step="0.05"
+          min="0"
+          max="1"
+        />
+        <InputRange
+          value={data.rate}
+          onChange={(e) => handleUpdate("rate", e.target.value)}
+          label="common.field_rate"
+          step="0.05"
+          min="0.1"
+          max="5"
+        />
+      </Inspector.Deactivatable>
+    </>
+  );
+};
 
 const WordsReplacementModal: FC = () => {
-  const {t} = useTranslation();
+  const { t } = useTranslation();
   const data = useSnapshot(window.ApiServer.state.services.tts);
-  const up = <K extends keyof TTS_State>(key: K, v: TTS_State[K]) => window.ApiServer.patchService("tts", s => s.data[key] = v);
+  const up = <K extends keyof TTS_State>(key: K, v: TTS_State[K]) =>
+    window.ApiServer.patchService("tts", (s) => (s.data[key] = v));
 
-  return <Modal.Body width={420}>
-    <Modal.Header>{t('word_replacements.title')}</Modal.Header>
-    <Modal.Content>
-      <div className="p-4">
-        <InputCheckbox label="word_replacements.field_ignore_case" value={data.data.replaceWordsIgnoreCase} onChange={v => up("replaceWordsIgnoreCase", v)}/>
-        <InputMapObject keyPlaceholder={t('word_replacements.label_dictionary_key')} valuePlaceholder={t('word_replacements.label_dictionary_value')} addLabel="Add word" value={{...data.data.replaceWords}} onChange={e => up("replaceWords", e)} label="" />
-      </div>
-    </Modal.Content>
-  </Modal.Body>
-}
-NiceModal.register('tts-replacements', (props) => <Modal.Base {...props}><WordsReplacementModal /></Modal.Base>);
+  return (
+    <Modal.Body width={420}>
+      <Modal.Header>{t("word_replacements.title")}</Modal.Header>
+      <Modal.Content>
+        <div className="p-4">
+          <InputCheckbox
+            label="word_replacements.field_ignore_case"
+            value={data.data.replaceWordsIgnoreCase}
+            onChange={(v) => up("replaceWordsIgnoreCase", v)}
+          />
+          <InputMapObject
+            keyPlaceholder={t("word_replacements.label_dictionary_key")}
+            valuePlaceholder={t("word_replacements.label_dictionary_value")}
+            addLabel="Add word"
+            value={{ ...data.data.replaceWords }}
+            onChange={(e) => up("replaceWords", e)}
+            label=""
+          />
+        </div>
+      </Modal.Content>
+    </Modal.Body>
+  );
+};
+NiceModal.register("tts-replacements", (props) => (
+  <Modal.Base {...props}>
+    <WordsReplacementModal />
+  </Modal.Base>
+));
 
 const Inspector_TTS: FC = () => {
-  const {t} = useTranslation();
+  const { t } = useTranslation();
   const data = useSnapshot(window.ApiServer.state.services.tts);
-  const up = <K extends keyof TTS_State>(key: K, v: TTS_State[K]) => window.ApiServer.patchService("tts", s => s.data[key] = v);
-  const handleStart = (v: boolean) => window.ApiServer.state.services.tts.showActionButton = v;
+  const up = <K extends keyof TTS_State>(key: K, v: TTS_State[K]) =>
+    window.ApiServer.patchService("tts", (s) => (s.data[key] = v));
+  const handleStart = (v: boolean) =>
+    (window.ApiServer.state.services.tts.showActionButton = v);
   const state = useSnapshot(window.ApiServer.tts.serviceState);
   const handleShowReplacements = () => {
-    NiceModal.show('tts-replacements');
-  }
+    NiceModal.show("tts-replacements");
+  };
 
-  return <Inspector.Body>
-    <Inspector.Header><RiChatVoiceFill /> {t('tts.title')}</Inspector.Header>
-    <Inspector.Content>
-      <InputCheckbox label="common.field_action_bar" value={data.showActionButton} onChange={handleStart} />
-      <InputCheckbox label="common.field_auto_start" value={data.data.autoStart} onChange={e => up("autoStart", e)} />
-      <InputCheckbox label="tts.field_stop_with_stream" value={data.data.stopWithStream} onChange={e => up("stopWithStream", e)} />
-      <span className="link link-accent link-hover font-semibold flex items-center gap-2 text-sm" onClick={handleShowReplacements}><RiCharacterRecognitionFill/> {t('common.btn_edit_replacements')}</span>
-      <Inspector.Deactivatable active={state.status === ServiceNetworkState.disconnected}>
-        <InputTextSource label="common.field_text_source" value={data.data.source} onChange={e => up("source", e)} />
-        <InputCheckbox label="common.field_use_keyboard_input" value={data.data.inputField} onChange={e => up("inputField", e)} />
-        <InputSelect label="common.field_service" value={data.data.backend} options={[
-          { label: "Native", value: TTS_Backends.native },
-          { label: "Windows", value: TTS_Backends.windows },
-          { label: "Azure", value: TTS_Backends.azure },
-          { label: "TikTok", value: TTS_Backends.tiktok },
-          { label: "Uberduck", value: TTS_Backends.uberduck },
-          // { label: "VoiceVox", value: TTS_Backends.voicevox },
-        ]} onValueChange={e => up("backend", e as TTS_Backends)} />
-      </Inspector.Deactivatable>
-      {data.data.backend === TTS_Backends.windows && <Windows />}
-      {data.data.backend === TTS_Backends.azure && <Azure />}
-      {data.data.backend === TTS_Backends.native && <Native />}
-      {data.data.backend === TTS_Backends.tiktok && <TikTok />}
-      {data.data.backend === TTS_Backends.uberduck && <UberDuck />}
-      {/* {data.data.backend === TTS_Backends.voicevox && <VoiceVox />} */}
-      <ServiceButton status={state.status} onStart={() => window.ApiServer.tts.start()} onStop={() => window.ApiServer.tts.stop()} />
-    </Inspector.Content>
-  </Inspector.Body>
-}
+  return (
+    <Inspector.Body>
+      <Inspector.Header>
+        <RiChatVoiceFill /> {t("tts.title")}
+      </Inspector.Header>
+      <Inspector.Content>
+        <InputCheckbox
+          label="common.field_action_bar"
+          value={data.showActionButton}
+          onChange={handleStart}
+        />
+        <InputCheckbox
+          label="common.field_auto_start"
+          value={data.data.autoStart}
+          onChange={(e) => up("autoStart", e)}
+        />
+        <InputCheckbox
+          label="tts.field_stop_with_stream"
+          value={data.data.stopWithStream}
+          onChange={(e) => up("stopWithStream", e)}
+        />
+        <span
+          className="link link-accent link-hover font-semibold flex items-center gap-2 text-sm"
+          onClick={handleShowReplacements}
+        >
+          <RiCharacterRecognitionFill /> {t("common.btn_edit_replacements")}
+        </span>
+        <Inspector.Deactivatable
+          active={state.status === ServiceNetworkState.disconnected}
+        >
+          <InputTextSource
+            label="common.field_text_source"
+            value={data.data.source}
+            onChange={(e) => up("source", e)}
+          />
+          <InputCheckbox
+            label="common.field_use_keyboard_input"
+            value={data.data.inputField}
+            onChange={(e) => up("inputField", e)}
+          />
+          <InputSelect
+            label="common.field_service"
+            value={data.data.backend}
+            options={[
+              { label: "Native", value: TTS_Backends.native },
+              { label: "Windows", value: TTS_Backends.windows },
+              { label: "Azure", value: TTS_Backends.azure },
+              { label: "TikTok", value: TTS_Backends.tiktok },
+              { label: "Edge", value: TTS_Backends.edge },
+              { label: "Uberduck", value: TTS_Backends.uberduck },
+              // { label: "VoiceVox", value: TTS_Backends.voicevox },
+            ]}
+            onValueChange={(e) => up("backend", e as TTS_Backends)}
+          />
+        </Inspector.Deactivatable>
+        {data.data.backend === TTS_Backends.windows && <Windows />}
+        {data.data.backend === TTS_Backends.azure && <Azure />}
+        {data.data.backend === TTS_Backends.native && <Native />}
+        {data.data.backend === TTS_Backends.tiktok && <TikTok />}
+        {data.data.backend === TTS_Backends.edge && <Edge />}
+        {data.data.backend === TTS_Backends.uberduck && <UberDuck />}
+        {/* {data.data.backend === TTS_Backends.voicevox && <VoiceVox />} */}
+        <ServiceButton
+          status={state.status}
+          onStart={() => window.ApiServer.tts.start()}
+          onStop={() => window.ApiServer.tts.stop()}
+        />
+      </Inspector.Content>
+    </Inspector.Body>
+  );
+};
 
 export default Inspector_TTS;


### PR DESCRIPTION
## Summary
- hook up `edge-tts` library via named import
- add Edge backend configuration in inspector
- allow selecting voices from `edge-tts` dynamically
- translate new labels for English and Chinese locales

## Testing
- `pnpm exec playwright test` *(fails: browsers missing)*